### PR TITLE
Avatar Tooltip Flickering Fixed

### DIFF
--- a/src/components/HorizontalAvatarList.js
+++ b/src/components/HorizontalAvatarList.js
@@ -30,6 +30,8 @@ const HorizontalAvatarList = ({
                   zIndex: index,
                   border: '3px solid #fff',
                   marginLeft: !isFirstItem && -20,
+                  marginBottom: '20px',
+                  marginTop:'20px'
                 }}
               />
 

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -348,14 +348,14 @@ class DashboardPage extends React.Component {
         </Row>
 
         <CardDeck style={{ marginBottom: '1rem' }}>
-          <Card body style={{ overflowX: 'auto' }}>
+          <Card body style={{ overflowX: 'auto','paddingBottom':'15px','height': 'fit-content','paddingTop': 'inherit'}}>
             <HorizontalAvatarList
               avatars={avatarsData}
               avatarProps={{ size: 50 }}
             />
           </Card>
 
-          <Card body style={{ overflowX: 'auto' }}>
+          <Card body style={{ overflowX: 'auto','paddingBottom':'15px','height': 'fit-content','paddingTop': 'inherit'}}>
             <HorizontalAvatarList
               avatars={avatarsData}
               avatarProps={{ size: 50 }}


### PR DESCRIPTION
Flickering of Tooltip of Avatars from the Horizontal Avatar List on Dashboard has been fixed with minimal modular independent changes. While the user hovers over each of the avatar from the Horizontal Avatar List on the Dashboard,  if the hover is in the lower 50% of the circle of Avatar, the tooltip goes on flickering and eventually, the pages gets stuck. I have resolved the same, using minimal independent, modular changes. Please merge if it is suitable. 