### PR TITLE
Clear tableTypes collection when TablePage unmounts to avoid memory leak

### DIFF
--- a/src/pages/TablePage.js
+++ b/src/pages/TablePage.js
@@ -1,10 +1,18 @@
 import Page from 'components/Page';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Card, CardBody, CardHeader, Col, Row, Table } from 'reactstrap';
 
 const tableTypes = ['', 'bordered', 'striped', 'hover'];
 
 const TablePage = () => {
+  useEffect(() => {
+    return () => {
+      if (tableTypes && tableTypes.length) {
+        tableTypes.splice(0, tableTypes.length);
+      }
+    };
+  }, []);
+
   return (
     <Page
       title="Tables"


### PR DESCRIPTION
Hello 👋 
As part of our project, we are using Facebook's new Memlab tool to detect memory leaks in SPA applications. 
While running the tool and analyzing the code of react-reduction, we saw that your project does a very good job of ensuring that all async operations are cancelled when the component unmounts. However, as per Memlab execution results, we found a dangling collection that was causing the memory to leak (screenshots below).

[before]
<img width="1153" alt="Screen Shot 2023-01-28 at 4 47 49 PM" src="https://user-images.githubusercontent.com/56495631/215302893-6f1e5cc9-457c-4125-9b78-4b836cdb9837.png">

<br />
Hence we added the fix by clearing the collection on unmount, and you can see the heap size and # of leaks reducing noticeably:
<br />
<img width="1132" alt="Screen Shot 2023-01-28 at 6 25 33 PM" src="https://user-images.githubusercontent.com/56495631/215302936-45c52ccc-8e1a-4599-bfb5-cd8fd6432b9c.png">

Note: We used `splice` instead of the more conventional `.length=0`, to cater for any future modifications where `tableTypes` may have a length property but is not assignable.

You can analyze this and other potential leak sources, if you like, by running [Memlab](https://facebook.github.io/memlab/) with a scenario file covering the maximum # of use cases.
Following is a sample of the scenario file we used (it needs to be a .js file but attaching here in .txt form):

[react-reduction-memlab-scenario.txt](https://github.com/reduction-admin/react-reduction/files/10528875/react-reduction-memlab-scenario.txt)

Note that some other reported leaks (in Memlab) originated from React's internal objects, and hence were ignored.